### PR TITLE
fixed read_crv issue where polars was reading from previously opened …

### DIFF
--- a/oakvar/lib/util/inout.py
+++ b/oakvar/lib/util/inout.py
@@ -630,14 +630,14 @@ class ColumnDefinition(object):
 def read_crv(fpath):
     import polars as pl
 
-    f = open(fpath)
-    c = 0
-    for line in f:
-        if not line.startswith("#"):
-            break
-        c += 1
+    with open(fpath) as f:
+        c = 0
+        with open(fpath) as f:
+            for line in f:
+                if line.startswith("#"):
+                    c += 1
     df = pl.read_csv(
-        f,
+        fpath,
         skip_rows=c,
         new_columns=["uid", "chrom", "pos", "pos_end", "ref_base", "alt_base"],
     )


### PR DESCRIPTION
I was trying to use the `read_crv(fpath)` function while trying to construct the SPDI converter - but it ended up giving [this](https://pastebin.com/ddyqwYPi) error. This is due to `f=open(fpath)` being open as it is being passed to `df`. The code closes it and gives the [expected output](https://pastebin.com/Rz4qfgCL). Both outputs are from a Python test script with `read_crv from inout.py v2.9.36` being tested and giving the error, while the below script change in PR#53 gives the second output. The test file used is exampleinput.crv. 

