### PR TITLE
read_crv first row deletion fix

### DIFF
--- a/oakvar/lib/util/inout.py
+++ b/oakvar/lib/util/inout.py
@@ -630,17 +630,17 @@ class ColumnDefinition(object):
 def read_crv(fpath):
     import polars as pl
 
-    with open(fpath) as f:
-        c = 0
-        with open(fpath) as f:
-            for line in f:
-                if line.startswith("#"):
-                    c += 1
+    # Read the CSV using the comment character
     df = pl.read_csv(
         fpath,
-        skip_rows=c,
-        new_columns=["uid", "chrom", "pos", "pos_end", "ref_base", "alt_base"],
+        comment_char='#',
+        has_header=False,
+        new_columns=["uid", "chrom", "pos", "pos_end", "ref_base", "alt_base"]
     )
+    
+    # Select only the first 6 columns to return
+    df = df.select(["uid", "chrom", "pos", "pos_end", "ref_base", "alt_base"])
+
     return df
 
 


### PR DESCRIPTION
The old script was skipping row 1 and inserting it as a header, and then replacing the header with new_columns. 

When `has_header=False` is specified, it fixes the row deletion issue but then reads the final comma of the .crv file as an additional column. Thus, df.select is needed to ignore that column.

 I also replaced the while loop with the inbuilt comment_char = # from the Polars documentation, which is handy. 